### PR TITLE
Modernize for Ruby 3.2+ (WA-NEW-021)

### DIFF
--- a/active_model-unvalidate.gemspec
+++ b/active_model-unvalidate.gemspec
@@ -1,4 +1,3 @@
-
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "active_model/unvalidate/version"
@@ -14,8 +13,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/weblinc/active_model-unvalidate"
   spec.license       = "MIT"
 
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  spec.required_ruby_version = [">= 2.7", "< 3.5"]
+
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
@@ -23,10 +22,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activemodel", '> 4.0.0'
-  spec.add_dependency "activesupport", '> 4.0.0'
+  spec.add_dependency "activemodel", ">= 6.0"
+  spec.add_dependency "activesupport", ">= 6.0"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", ">= 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 end

--- a/lib/active_model/unvalidate.rb
+++ b/lib/active_model/unvalidate.rb
@@ -35,8 +35,8 @@ module ActiveModel
         end
         _validate_callbacks.select do |callback|
           is_callback_class?(callback) &&
-            callback.raw_filter.attributes.include?(field) &&
-              validations.include?(extract_validator_name(callback.raw_filter))
+            callback_filter(callback).attributes.include?(field) &&
+              validations.include?(extract_validator_name(callback_filter(callback)))
         end.each do |callback|
           _validate_callbacks.delete(callback)
         end
@@ -53,7 +53,7 @@ module ActiveModel
           key == field
         end
         _validate_callbacks.select do |callback|
-          is_callback_class?(callback) && callback.raw_filter.attributes.include?(field)
+          is_callback_class?(callback) && callback_filter(callback).attributes.include?(field)
         end.each do |callback|
           _validate_callbacks.delete(callback)
         end
@@ -67,7 +67,7 @@ module ActiveModel
       #
       def unvalidate(method)
         _validate_callbacks.select do |callback|
-          callback.raw_filter == method
+          callback_filter(callback) == method
         end.each do |callback|
           _validate_callbacks.delete(callback)
         end
@@ -75,12 +75,17 @@ module ActiveModel
 
       private
 
+      def callback_filter(callback)
+        # Rails < 7.1 used raw_filter; Rails 7.1+ uses filter
+        callback.respond_to?(:raw_filter) ? callback.raw_filter : callback.filter
+      end
+
       def extract_validator_name(validator)
         validator.class.to_s.demodulize
       end
 
       def is_callback_class?(callback)
-        callback.raw_filter.respond_to?(:attributes)
+        callback_filter(callback).respond_to?(:attributes)
       end
     end
   end


### PR DESCRIPTION
## Summary

Modernizes `active_model-unvalidate` to run cleanly on Ruby 3.2+ without deprecation warnings or errors.

## Changes

- **gemspec**: Add `required_ruby_version >= 2.7, < 3.5`; update `activemodel`/`activesupport` deps to `>= 6.0`; loosen `bundler` dev dep to `>= 2.0`
- **lib/active_model/unvalidate.rb**: Replace removed `raw_filter` API (removed in Rails 7.1+) with backward-compatible `callback_filter` helper that uses `filter` on newer Rails

## Testing

Tests pass on Ruby 3.2.7:
```
3 runs, 8 assertions, 0 failures, 0 errors, 0 skips
```

## Related

Part of WA-NEW-021: Plugin modernization Phase 1

Client impact: None — internal dependency